### PR TITLE
Fix note title generation

### DIFF
--- a/lua/lnvim/llm.lua
+++ b/lua/lnvim/llm.lua
@@ -261,7 +261,7 @@ end
 local function generate_args(model, system_prompt, prompt, messages, streaming)
    local is_streaming = true
    if streaming ~= nil then
-      is_streaming = is_streaming
+      is_streaming = streaming
    end
    local args = {
       "-N",
@@ -903,8 +903,17 @@ end
 function M.focused_query(opts)
    local model = opts.model
    local callback = opts.on_complete
+
+   local file_contents = ""
+   if opts.files then
+      for _, file in ipairs(opts.files) do
+         local content = vim.fn.readfile(file)
+         file_contents = file_contents .. "\n\nNote Content:\n" .. table.concat(content, "\n")
+      end
+   end
+
    local messages = {
-      { role = "system", content = opts.system_prompt },
+      { role = "system", content = opts.system_prompt .. file_contents },
       { role = "user",   content = opts.prompt }
    }
 


### PR DESCRIPTION
* Fixed a typo in generate_args that caused streaming mode to always be on
* Now includes the note content in prompt. memex.lua was passing in a file= arg to focused_query that was never read. That now gets read in.
  * Note that it does hardcode the string "Note Content: " for anything with the files arg, maybe makes it less general, not sure if worth fixing or not.

To test: <leader>;n, make a new note, then decline to enter a title (while having a working wtf_model)